### PR TITLE
Migrate to Swift 5 and Change date format

### DIFF
--- a/MovieBox/MovieBox.xcodeproj/project.pbxproj
+++ b/MovieBox/MovieBox.xcodeproj/project.pbxproj
@@ -859,9 +859,11 @@
 					};
 					62A2A60421A9C9E4007F821B = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1150;
 					};
 					62A2A61721A9C9E5007F821B = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1150;
 						TestTargetID = 62A2A60421A9C9E4007F821B;
 					};
 				};
@@ -1368,7 +1370,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVC;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1387,7 +1389,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVC;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1407,7 +1409,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVCTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MovieBoxMVC.app/MovieBoxMVC";
 			};
@@ -1428,7 +1430,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVCTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MovieBoxMVC.app/MovieBoxMVC";
 			};
@@ -1449,7 +1451,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxVIPER;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1469,7 +1471,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxVIPER;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1490,7 +1492,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxVIPERTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MovieBoxVIPER.app/MovieBoxVIPER";
 			};
@@ -1512,7 +1514,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxVIPERTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MovieBoxVIPER.app/MovieBoxVIPER";
 			};
@@ -1531,7 +1533,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVVM;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1549,7 +1551,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVVM;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1569,7 +1571,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVVMTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MovieBoxMVVM.app/MovieBoxMVVM";
 			};
@@ -1590,7 +1592,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxMVVMTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MovieBoxMVVM.app/MovieBoxMVVM";
 			};

--- a/MovieBoxAPI/MovieBoxAPI.xcodeproj/project.pbxproj
+++ b/MovieBoxAPI/MovieBoxAPI.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 				TargetAttributes = {
 					3635F03F2184FDB900D9215B = {
 						CreatedOnToolsVersion = 10.0;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1150;
 					};
 					3635F0502184FE4D00D9215B = {
 						CreatedOnToolsVersion = 10.0;
@@ -248,6 +248,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 3635F0362184FDB900D9215B;
 			productRefGroup = 3635F0412184FDB900D9215B /* Products */;
@@ -454,7 +455,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -480,7 +481,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.MovieBoxAPI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/MovieBoxAPI/MovieBoxAPI/DTOs/Movie.swift
+++ b/MovieBoxAPI/MovieBoxAPI/DTOs/Movie.swift
@@ -20,7 +20,7 @@ public struct Movie: Decodable, Equatable {
     }
     
     public let artistName: String
-    public let releaseDate: Date
+    public let releaseDate: String
     public let name: String
     public let copyright: String?
     public let image: URL

--- a/MovieBoxAPI/MovieBoxAPI/Helpers/Decoders.swift
+++ b/MovieBoxAPI/MovieBoxAPI/Helpers/Decoders.swift
@@ -12,8 +12,7 @@ public enum Decoders {
     public static let plainDateDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MM/dd/yyyy"
-//        "yyyy-MM-dd"
+        dateFormatter.dateFormat = "yyyy-MM-dd"
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
         return decoder
     }()

--- a/MovieBoxAPI/MovieBoxAPI/Helpers/Decoders.swift
+++ b/MovieBoxAPI/MovieBoxAPI/Helpers/Decoders.swift
@@ -12,7 +12,8 @@ public enum Decoders {
     public static let plainDateDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.dateFormat = "MM/dd/yyyy"
+//        "yyyy-MM-dd"
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
         return decoder
     }()

--- a/MovieBoxAPI/MovieBoxAPI/TopMoviesService.swift
+++ b/MovieBoxAPI/MovieBoxAPI/TopMoviesService.swift
@@ -25,7 +25,7 @@ public class TopMoviesService: TopMoviesServiceProtocol {
     public func fetchTopMovies(completion: @escaping (Result<TopMoviesResponse>) -> Void) {
         let urlString = "https://rss.itunes.apple.com/api/v1/us/movies/top-movies/all/25/explicit.json"
         
-        request(urlString).responseData { (response) in
+        AF.request(urlString).responseData { (response) in
             switch response.result {
             case .success(let data):
                 let decoder = Decoders.plainDateDecoder

--- a/Utility/Utility.xcodeproj/project.pbxproj
+++ b/Utility/Utility.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 				TargetAttributes = {
 					363E032121A1E284009E34F0 = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1150;
 					};
 					363E032A21A1E284009E34F0 = {
 						CreatedOnToolsVersion = 10.1;
@@ -191,6 +191,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 363E031821A1E284009E34F0;
 			productRefGroup = 363E032321A1E284009E34F0 /* Products */;
@@ -393,7 +394,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -419,7 +420,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.latenight.Utility;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Utility/Utility/Extensions/Array+Helpers.swift
+++ b/Utility/Utility/Extensions/Array+Helpers.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public extension Array {
     
-    public struct IndexOutOfBoundsError: Error { }
+    struct IndexOutOfBoundsError: Error { }
     
-    public func element(at index: Int) throws -> Element {
+    func element(at index: Int) throws -> Element {
         guard index >= 0 && index < self.count else {
             throw IndexOutOfBoundsError()
         }

--- a/Utility/Utility/Extensions/Optional+Helpers.swift
+++ b/Utility/Utility/Extensions/Optional+Helpers.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public extension Optional {
     
-    public struct FoundNilWhileUnwrappingError: Error { }
+    struct FoundNilWhileUnwrappingError: Error { }
     
-    public func unwrap() throws -> Wrapped {
+    func unwrap() throws -> Wrapped {
         switch self {
         case .some(let wrapped):
             return wrapped

--- a/Vendor/Cartfile.resolved
+++ b/Vendor/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.7.3"
+github "Alamofire/Alamofire" "5.2.2"


### PR DESCRIPTION
-I migrated Swift version to Swift 5 and changed releaseDate object data model from Date to String. 
-I migrated Alamofire version to Alamofire 5.2.2